### PR TITLE
Fix for the ARM64/Docker build issue

### DIFF
--- a/MarketData/MarketData.csproj
+++ b/MarketData/MarketData.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore" Version="2.76.0" />
+    <!-- Pinned to Grpc.Tools 2.80.0-pre1 for required ARM64/Docker gRPC tooling fixes; update to a stable Grpc.Tools >= 2.80.0 when it includes this fix and remove this comment. -->
     <PackageReference Include="Grpc.Tools" Version="2.80.0-pre1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Attempt fix for the ARM64/Docker build issue by adding an explicit reference to Grpc.Tools version 2.80.0-pre1. Possible cause of error: Grpc.AspNetCore package includes Grpc.Tools as a dependency, but was using an older version (2.70.0) that has known issues with ARM64 architectures